### PR TITLE
added code to avoid lightgbm reshaping warning

### DIFF
--- a/gbnet/lgbmodule.py
+++ b/gbnet/lgbmodule.py
@@ -122,4 +122,6 @@ class LightGBObj:
         self.hess = hess.detach().numpy()
 
     def __call__(self, y_true, y_pred):
-        return self.grad, self.hess
+        if self.grad.shape[1] > 1:
+            return self.grad, self.hess
+        return self.grad.flatten(), self.hess.flatten()


### PR DESCRIPTION
avoids `UserWarning: Converting column-vector to 1d array
  _log_warning("Converting column-vector to 1d array")`