### PR TITLE
removed construct for lgb.Dataset

### DIFF
--- a/gbnet/lgbmodule.py
+++ b/gbnet/lgbmodule.py
@@ -1,5 +1,4 @@
 from typing import Union
-import warnings
 import lightgbm as lgb
 import numpy as np
 import pandas as pd
@@ -30,7 +29,6 @@ class LGBModule(nn.Module):
             )
         )
         self.train_dat = None
-        self.training_n = None
 
     def _set_train_dat(self, input_dataset: lgb.Dataset):
         if input_dataset.params is None:
@@ -39,13 +37,6 @@ class LGBModule(nn.Module):
             input_dataset.params.update({"verbose": -1})
         input_dataset.free_raw_data = False
         self.train_dat = input_dataset
-        self.train_dat.construct()
-
-    def _check_training_data(self):
-        if self.train_dat.get_weight() is not None:
-            warnings.warn(
-                "Weights will not work properly when defined as part of the input Dataset. Weights should be defined in the loss."
-            )
 
     def _input_checking_setting(
         self, input_dataset: Union[lgb.Dataset, np.ndarray, pd.DataFrame]
@@ -58,19 +49,6 @@ class LGBModule(nn.Module):
                     if isinstance(input_dataset, lgb.Dataset)
                     else lgb.Dataset(input_dataset)
                 )
-                self.training_n = self.train_dat.num_data()
-                self._check_training_data()
-            if isinstance(input_dataset, lgb.Dataset):
-                input_dataset.construct()
-
-            check_n = (
-                input_dataset.num_data()
-                if isinstance(input_dataset, lgb.Dataset)
-                else input_dataset.shape[0]
-            )
-            assert (
-                check_n == self.training_n
-            ), "Changing datasets while training is not currently supported. If trying to make predictions, set Module to eval mode via `Module.eval()`"
             return self.train_dat
 
         if isinstance(input_dataset, lgb.Dataset):

--- a/gbnet/lgbmodule.py
+++ b/gbnet/lgbmodule.py
@@ -49,6 +49,16 @@ class LGBModule(nn.Module):
                     if isinstance(input_dataset, lgb.Dataset)
                     else lgb.Dataset(input_dataset)
                 )
+            if self.bst is None:
+                return self.train_dat
+            if isinstance(input_dataset, lgb.Dataset):
+                assert (
+                    input_dataset._handle is not None
+                ), "Changing datasets during training is not supported. If trying to do prediction, call LGBModule.eval() first."
+            else:  # NEW
+                assert (
+                    self.batch_size == input_dataset.shape[0]
+                ), "Changing datasets during training is not supported. If trying to do prediction, call LGBModule.eval() first."
             return self.train_dat
 
         if isinstance(input_dataset, lgb.Dataset):

--- a/gbnet/tests/test_lgbmodule.py
+++ b/gbnet/tests/test_lgbmodule.py
@@ -138,3 +138,54 @@ class TestLGBModule(TestCase):
         data = [1, 2, 3]  # Invalid type
         with self.assertRaises(AssertionError):
             module._input_checking_setting(data)
+
+    def test_if_bst_is_none(self):
+        """
+        Test scenario where self.training = True, self.train_dat is not None,
+        and self.bst is None. The method should return self.train_dat directly.
+        """
+        module = lgm.LGBModule(10, 5, 1)
+        arr = np.random.rand(10, 5)
+        module._set_train_dat(lgb.Dataset(arr))
+
+        # Since bst is None, method should return train_dat directly
+        result = module._input_checking_setting(np.random.rand(10, 5))
+        self.assertIs(
+            result, module.train_dat, "Expected to return train_dat when bst is None."
+        )
+
+    def test_raises_input_changed_lgb_dataset(self):
+        """
+        Test scenario where self.training = True, self.train_dat not None,
+        self.bst not None, and input_dataset is an lgb.Dataset with a _handle.
+        Expect no assertion error and return self.train_dat.
+        """
+        module = lgm.LGBModule(10, 5, 1)
+        arr = np.random.rand(10, 5)
+        initial_dataset = lgb.Dataset(arr)
+        initial_dataset.construct()
+        module._set_train_dat(initial_dataset)
+
+        # bst is non-None now
+        module.bst = object()
+
+        with self.assertRaises(AssertionError):
+            module._input_checking_setting(lgb.Dataset(np.random.random([10, 5])))
+
+    def test_raises_input_changed_ndarray(self):
+        """
+        Test scenario where self.training = True, self.train_dat not None,
+        self.bst not None, and input_dataset is an lgb.Dataset with a _handle.
+        Expect no assertion error and return self.train_dat.
+        """
+        module = lgm.LGBModule(10, 5, 1)
+        arr = np.random.rand(10, 5)
+        initial_dataset = lgb.Dataset(arr)
+        initial_dataset.construct()
+        module._set_train_dat(initial_dataset)
+
+        # bst is non-None now
+        module.bst = object()
+
+        with self.assertRaises(AssertionError):
+            module._input_checking_setting(np.random.random([11, 5]))

--- a/gbnet/tests/test_lgbmodule.py
+++ b/gbnet/tests/test_lgbmodule.py
@@ -75,8 +75,6 @@ class TestLGBModule(TestCase):
         result = module._input_checking_setting(dataset)
         self.assertIs(result, module.train_dat)
         self.assertIsInstance(result, lgb.Dataset)
-        self.assertEqual(module.training_n, module.train_dat.num_data())
-        self.assertEqual(module.training_n, dataset.num_data())
 
     def test_input_is_ndarray_training_true_train_dat_none(self):
         """Test with np.ndarray input, training mode True, and train_dat is None."""
@@ -85,8 +83,6 @@ class TestLGBModule(TestCase):
         result = module._input_checking_setting(data)
         self.assertIs(result, module.train_dat)
         self.assertIsInstance(result, lgb.Dataset)
-        self.assertEqual(module.training_n, module.train_dat.num_data())
-        self.assertEqual(module.training_n, 100)
 
     def test_input_is_dataframe_training_true_train_dat_none(self):
         """Test with pd.DataFrame input, training mode True, and train_dat is None."""
@@ -95,8 +91,6 @@ class TestLGBModule(TestCase):
         result = module._input_checking_setting(data)
         self.assertIs(result, module.train_dat)
         self.assertIsInstance(result, lgb.Dataset)
-        self.assertEqual(module.training_n, module.train_dat.num_data())
-        self.assertEqual(module.training_n, 100)
 
     def test_input_is_dataset_training_true_train_dat_set_same_nrows(self):
         """Test with lgb.Dataset input, training mode True, train_dat set, same number of data."""
@@ -106,19 +100,6 @@ class TestLGBModule(TestCase):
         result = module._input_checking_setting(dataset)
         self.assertIs(result, module.train_dat)
         self.assertIs(result, dataset)
-
-    def test_input_is_dataset_training_true_train_dat_set_different_nrows(self):
-        """Test with lgb.Dataset input, training mode True, train_dat set, different number of data."""
-        module = lgm.LGBModule(100, 10, 1)
-        data1 = np.random.rand(100, 10)
-        module(data1)
-        data2 = np.random.rand(50, 10)
-        with self.assertRaises(AssertionError) as context:
-            module(data2)
-        self.assertIn(
-            "Changing datasets while training is not currently supported",
-            str(context.exception),
-        )
 
     def test_input_is_dataset_training_false(self):
         """Test with lgb.Dataset input and training mode False."""


### PR DESCRIPTION
Construct for lgb.Dataset was useful to get statistics about the training set, but it caused too many inconveniences. Removing most of construct usage and replacing with other checks.